### PR TITLE
Center reset button and enlarge mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,15 +14,15 @@
     class="bg-black block mx-auto"
   ></canvas>
   <div id="score">Score: 0</div>
-  <button id="restart" class="hidden mt-2 py-2 px-5 text-xl">Restart</button>
+  <button id="restart" class="hidden mx-auto mt-2 py-2 px-5 text-xl border-2 border-gray-700">Restart</button>
   <div id="controls" class="mt-5 inline-block">
     <div class="row flex justify-center">
-      <button id="up" aria-label="up" class="w-20 h-20 text-4xl m-[5px]">↑</button>
+      <button id="up" aria-label="up" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">↑</button>
     </div>
     <div class="row flex justify-center">
-      <button id="left" aria-label="left" class="w-20 h-20 text-4xl m-[5px]">←</button>
-      <button id="down" aria-label="down" class="w-20 h-20 text-4xl m-[5px]">↓</button>
-      <button id="right" aria-label="right" class="w-20 h-20 text-4xl m-[5px]">→</button>
+      <button id="left" aria-label="left" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">←</button>
+      <button id="down" aria-label="down" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">↓</button>
+      <button id="right" aria-label="right" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">→</button>
     </div>
   </div>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- Center the restart button and add a border for visibility
- Enlarge on-screen arrow keys on mobile while keeping desktop size

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898332f5ee88328bc51fefe90adb2e5