### PR TITLE
style: enlarge mobile arrow buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,12 +17,12 @@
   <button id="restart" class="hidden mx-auto mt-2 py-2 px-5 text-xl border-2 border-gray-700">Restart</button>
   <div id="controls" class="mt-5 inline-block">
     <div class="row flex justify-center">
-      <button id="up" aria-label="up" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">↑</button>
+      <button id="up" aria-label="up" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">↑</button>
     </div>
     <div class="row flex justify-center">
-      <button id="left" aria-label="left" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">←</button>
-      <button id="down" aria-label="down" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">↓</button>
-      <button id="right" aria-label="right" class="w-40 h-40 text-[9rem] m-[5px] sm:w-20 sm:h-20 sm:text-4xl">→</button>
+      <button id="left" aria-label="left" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">←</button>
+      <button id="down" aria-label="down" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">↓</button>
+      <button id="right" aria-label="right" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">→</button>
     </div>
   </div>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- style arrow controls as circular buttons with border
- enlarge mobile arrow labels to text-[48rem]

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689836855c04832882e4272896433b36