### PR TITLE
feat: spawn multiple food items

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Use arrow keys or the on-screen buttons to steer the snake and collect food.
 - When only three items remain, new food spawns every few seconds until there are eight.
 - Each food is worth 10 points and grows the snake by one tile.
 - Game ends if the snake is stuck against a wall or itself for more than one second.
+- The snake blinks between green and red when it collides with itself, giving you a moment to steer away.
 
 To play locally, open `index.html` in a browser.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Snake Game
 
-Simple web-based Snake game. Open `index.html` in a browser to play. Use arrow keys to steer the snake and collect items. The game begins with five items on the board and periodically adds more when only three remain, up to a maximum of eight at once. Each item is worth 10 points and extends the snake by one tile. The board is 35x35 tiles and the snake moves every 0.2 seconds. If the snake is stuck against a wall or itself for more than one second, the game ends.
+Play online at https://a-yasui.github.io/snake-game-test/.
+
+Use arrow keys or the on-screen buttons to steer the snake and collect food.
+
+## Gameplay
+
+- Board is 35x35 tiles and the snake moves every 0.2 seconds.
+- Game starts with five food items on the board.
+- When only three items remain, new food spawns every few seconds until there are eight.
+- Each food is worth 10 points and grows the snake by one tile.
+- Game ends if the snake is stuck against a wall or itself for more than one second.
+
+To play locally, open `index.html` in a browser.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Snake Game
 
-Simple web-based Snake game. Open `index.html` in a browser to play. Use arrow keys to steer the snake and collect items. Each item is worth 10 points and extends the snake by one tile. The board is 35x35 tiles and the snake moves every 0.2 seconds. If the snake is stuck against a wall or itself for more than one second, the game ends.
+Simple web-based Snake game. Open `index.html` in a browser to play. Use arrow keys to steer the snake and collect items. The game begins with five items on the board and periodically adds more when only three remain, up to a maximum of eight at once. Each item is worth 10 points and extends the snake by one tile. The board is 35x35 tiles and the snake moves every 0.2 seconds. If the snake is stuck against a wall or itself for more than one second, the game ends.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Use arrow keys or the on-screen buttons to steer the snake and collect food.
 - Each food is worth 10 points and grows the snake by one tile.
 - Game ends if the snake is stuck against a wall or itself for more than one second.
 - The snake blinks between green and red when it collides with itself, giving you a moment to steer away.
+- The head displays an arrow (▲, ▼, ◀, ▶) indicating its current direction.
 
 To play locally, open `index.html` in a browser.
 

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ let score = 0;
 let moveInterval;
 let stuckTime = 0;
 let snakeColor = 'lime';
-let wallFlashInterval = null;
+let flashInterval = null;
 let foodSpawnInterval = null;
 
 function updateScoreDisplay(points) {
@@ -37,20 +37,20 @@ function highlightButton(id) {
   setTimeout(() => btn.classList.remove('bg-blue-500', 'text-white'), 200);
 }
 
-function startWallFlash() {
-  if (wallFlashInterval) return;
+function startFlash(interval = 50) {
+  if (flashInterval) return;
   snakeColor = 'red';
   draw();
-  wallFlashInterval = setInterval(() => {
+  flashInterval = setInterval(() => {
     snakeColor = snakeColor === 'lime' ? 'red' : 'lime';
     draw();
-  }, 50);
+  }, interval);
 }
 
-function stopWallFlash() {
-  if (!wallFlashInterval) return;
-  clearInterval(wallFlashInterval);
-  wallFlashInterval = null;
+function stopFlash() {
+  if (!flashInterval) return;
+  clearInterval(flashInterval);
+  flashInterval = null;
   snakeColor = 'lime';
 }
 
@@ -75,7 +75,7 @@ function stopFoodSpawner() {
 
 function initGame() {
   restartBtn.style.display = 'none';
-  stopWallFlash();
+  stopFlash();
   stopFoodSpawner();
   score = 0;
   document.getElementById('score').innerText = 'Score: ' + score;
@@ -174,7 +174,7 @@ function gameLoop() {
     head.y >= tileCount
   ) {
     stuckTime += moveTime;
-    startWallFlash();
+    startFlash();
     if (stuckTime >= stuckLimit) {
       gameOver();
     }
@@ -183,13 +183,14 @@ function gameLoop() {
 
   if (snake.some(seg => seg.x === head.x && seg.y === head.y)) {
     stuckTime += moveTime;
+    startFlash(100);
     if (stuckTime >= stuckLimit) {
       gameOver();
     }
     return;
   }
 
-  stopWallFlash();
+  stopFlash();
   stuckTime = 0;
   snake.unshift(head);
 
@@ -224,7 +225,7 @@ function draw() {
 }
 
 function gameOver() {
-  stopWallFlash();
+  stopFlash();
   stopFoodSpawner();
   clearInterval(moveInterval);
   ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';

--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ const initialFoodCount = 5;
 const foodSpawnThreshold = 3;
 const maxFoodCount = 8;
 const foodSpawnTime = 3000; // ms between new food spawns
+const blinkInterval = 100; // ms between snake color changes when flashing
 
 let snake = [];
 let direction = { x: 0, y: 0 };
@@ -37,7 +38,7 @@ function highlightButton(id) {
   setTimeout(() => btn.classList.remove('bg-blue-500', 'text-white'), 200);
 }
 
-function startFlash(interval = 50) {
+function startFlash(interval = blinkInterval) {
   if (flashInterval) return;
   snakeColor = 'red';
   draw();
@@ -183,7 +184,7 @@ function gameLoop() {
 
   if (snake.some(seg => seg.x === head.x && seg.y === head.y)) {
     stuckTime += moveTime;
-    startFlash(100);
+    startFlash();
     if (stuckTime >= stuckLimit) {
       gameOver();
     }
@@ -222,6 +223,25 @@ function draw() {
   snake.forEach(seg => {
     ctx.fillRect(seg.x * tileSize, seg.y * tileSize, tileSize, tileSize);
   });
+
+  const head = snake[0];
+  const arrow =
+    direction.x === 1
+      ? '▶'
+      : direction.x === -1
+      ? '◀'
+      : direction.y === 1
+      ? '▼'
+      : '▲';
+  ctx.fillStyle = 'white';
+  ctx.font = `${tileSize}px sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(
+    arrow,
+    head.x * tileSize + tileSize / 2,
+    head.y * tileSize + tileSize / 2
+  );
 }
 
 function gameOver() {


### PR DESCRIPTION
## Summary
- spawn five food items at game start and respawn when only three remain
- periodically add food up to eight items on board
- document multi-item spawning behavior

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68983f2b7cb48328b6867c6bc7d1a029