### PR TITLE
Add dynamic speed scaling and speed-up item to snake

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Use arrow keys or the on-screen buttons to steer the snake and collect food.
 
 ## Gameplay
 
-- Board is 35x35 tiles and the snake moves every 0.2 seconds.
+- Board is 35x35 tiles and the snake moves every 0.2 seconds. Speed increases to 0.15 seconds per move when the snake reaches length 10 and to 0.10 seconds per move at length 20.
 - Game starts with five food items on the board.
 - When only three items remain, new food spawns every few seconds until there are eight.
 - Each food is worth 10 points and grows the snake by one tile.
+- Occasionally a yellow speed-up item appears. Eating it makes the snake move ten times faster for a few seconds.
 - Game ends if the snake is stuck against a wall or itself for more than one second.
 - The snake blinks between green and red when it collides with itself, giving you a moment to steer away.
 - The head displays an arrow (▲, ▼, ◀, ▶) indicating its current direction.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use arrow keys or the on-screen buttons to steer the snake and collect food.
 
 ## Gameplay
 
-- Board is 35x35 tiles and the snake moves every 0.2 seconds. Speed increases to 0.15 seconds per move when the snake reaches length 10 and to 0.10 seconds per move at length 20.
+- Board is 35x35 tiles. The snake moves every 0.2 seconds and gains speed by 0.05 seconds for each 10 tiles of length (0.15s at length 10, 0.10s at length 20, down to a minimum of 0.05s).
 - Game starts with five food items on the board.
 - When only three items remain, new food spawns every few seconds until there are eight.
 - Each food is worth 10 points and grows the snake by one tile.

--- a/script.js
+++ b/script.js
@@ -4,7 +4,12 @@ const restartBtn = document.getElementById('restart');
 
 const tileCount = 35;
 const tileSize = canvas.width / tileCount;
-const moveTime = 200; // ms per move
+const baseMoveTime = 200; // ms per move
+const level10MoveTime = 150; // ms per move when length >= 10
+const level20MoveTime = 100; // ms per move when length >= 20
+const speedUpMultiplier = 10;
+const speedUpDuration = 5000; // ms speed boost duration
+const speedItemSpawnTime = 10000; // ms between speed item spawns
 const stuckLimit = 1000; // ms before game over when stuck
 const initialFoodCount = 5;
 const foodSpawnThreshold = 3;
@@ -16,12 +21,17 @@ let snake = [];
 let direction = { x: 0, y: 0 };
 let nextDirection = { x: 0, y: 0 };
 let foods = [];
+let speedItem = null;
 let score = 0;
 let moveInterval;
+let currentMoveTime = baseMoveTime;
+let speedUpActive = false;
+let speedUpTimeout = null;
 let stuckTime = 0;
 let snakeColor = 'lime';
 let flashInterval = null;
 let foodSpawnInterval = null;
+let speedItemSpawnInterval = null;
 
 function updateScoreDisplay(points) {
   const scoreEl = document.getElementById('score');
@@ -74,10 +84,71 @@ function stopFoodSpawner() {
   foodSpawnInterval = null;
 }
 
+function placeSpeedItem() {
+  let item;
+  do {
+    item = {
+      x: Math.floor(Math.random() * tileCount),
+      y: Math.floor(Math.random() * tileCount)
+    };
+  } while (
+    snake.some(seg => seg.x === item.x && seg.y === item.y) ||
+    foods.some(f => f.x === item.x && f.y === item.y)
+  );
+  speedItem = item;
+}
+
+function startSpeedItemSpawner() {
+  if (speedItemSpawnInterval) return;
+  speedItemSpawnInterval = setInterval(() => {
+    if (!speedItem) {
+      placeSpeedItem();
+      draw();
+    }
+  }, speedItemSpawnTime);
+}
+
+function stopSpeedItemSpawner() {
+  if (!speedItemSpawnInterval) return;
+  clearInterval(speedItemSpawnInterval);
+  speedItemSpawnInterval = null;
+}
+
+function getBaseMoveTime() {
+  if (snake.length >= 20) return level20MoveTime;
+  if (snake.length >= 10) return level10MoveTime;
+  return baseMoveTime;
+}
+
+function updateSpeed() {
+  const base = getBaseMoveTime();
+  const newTime = speedUpActive ? base / speedUpMultiplier : base;
+  if (newTime !== currentMoveTime) {
+    currentMoveTime = newTime;
+    clearInterval(moveInterval);
+    moveInterval = setInterval(gameLoop, currentMoveTime);
+  }
+}
+
+function activateSpeedUp() {
+  speedUpActive = true;
+  updateSpeed();
+  if (speedUpTimeout) clearTimeout(speedUpTimeout);
+  speedUpTimeout = setTimeout(() => {
+    speedUpActive = false;
+    updateSpeed();
+  }, speedUpDuration);
+}
+
 function initGame() {
   restartBtn.style.display = 'none';
   stopFlash();
   stopFoodSpawner();
+  stopSpeedItemSpawner();
+  if (speedUpTimeout) {
+    clearTimeout(speedUpTimeout);
+    speedUpTimeout = null;
+  }
   score = 0;
   document.getElementById('score').innerText = 'Score: ' + score;
   stuckTime = 0;
@@ -101,11 +172,15 @@ function initGame() {
   }
 
   foods = [];
+  speedItem = null;
   for (let i = 0; i < initialFoodCount; i++) {
     placeFood();
   }
+  currentMoveTime = baseMoveTime;
+  speedUpActive = false;
   if (moveInterval) clearInterval(moveInterval);
-  moveInterval = setInterval(gameLoop, moveTime);
+  moveInterval = setInterval(gameLoop, currentMoveTime);
+  startSpeedItemSpawner();
 }
 
 function placeFood() {
@@ -174,7 +249,7 @@ function gameLoop() {
     head.x >= tileCount ||
     head.y >= tileCount
   ) {
-    stuckTime += moveTime;
+    stuckTime += currentMoveTime;
     startFlash();
     if (stuckTime >= stuckLimit) {
       gameOver();
@@ -183,7 +258,7 @@ function gameLoop() {
   }
 
   if (snake.some(seg => seg.x === head.x && seg.y === head.y)) {
-    stuckTime += moveTime;
+    stuckTime += currentMoveTime;
     startFlash();
     if (stuckTime >= stuckLimit) {
       gameOver();
@@ -194,6 +269,11 @@ function gameLoop() {
   stopFlash();
   stuckTime = 0;
   snake.unshift(head);
+
+  if (speedItem && speedItem.x === head.x && speedItem.y === head.y) {
+    speedItem = null;
+    activateSpeedUp();
+  }
 
   const foodIndex = foods.findIndex(f => f.x === head.x && f.y === head.y);
   if (foodIndex !== -1) {
@@ -207,6 +287,7 @@ function gameLoop() {
     snake.pop();
   }
 
+  updateSpeed();
   draw();
 }
 
@@ -218,6 +299,11 @@ function draw() {
   foods.forEach(f => {
     ctx.fillRect(f.x * tileSize, f.y * tileSize, tileSize, tileSize);
   });
+
+  if (speedItem) {
+    ctx.fillStyle = 'yellow';
+    ctx.fillRect(speedItem.x * tileSize, speedItem.y * tileSize, tileSize, tileSize);
+  }
 
   ctx.fillStyle = snakeColor;
   snake.forEach(seg => {
@@ -247,6 +333,12 @@ function draw() {
 function gameOver() {
   stopFlash();
   stopFoodSpawner();
+  stopSpeedItemSpawner();
+  if (speedUpTimeout) {
+    clearTimeout(speedUpTimeout);
+    speedUpTimeout = null;
+  }
+  speedUpActive = false;
   clearInterval(moveInterval);
   ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
   ctx.fillRect(0, 0, canvas.width, canvas.height);

--- a/script.js
+++ b/script.js
@@ -5,8 +5,8 @@ const restartBtn = document.getElementById('restart');
 const tileCount = 35;
 const tileSize = canvas.width / tileCount;
 const baseMoveTime = 200; // ms per move
-const level10MoveTime = 150; // ms per move when length >= 10
-const level20MoveTime = 100; // ms per move when length >= 20
+const speedStep = 50; // ms faster for each 10 length
+const minMoveTime = 50; // ms minimum speed
 const speedUpMultiplier = 10;
 const speedUpDuration = 5000; // ms speed boost duration
 const speedItemSpawnTime = 10000; // ms between speed item spawns
@@ -115,9 +115,8 @@ function stopSpeedItemSpawner() {
 }
 
 function getBaseMoveTime() {
-  if (snake.length >= 20) return level20MoveTime;
-  if (snake.length >= 10) return level10MoveTime;
-  return baseMoveTime;
+  const reduction = Math.floor(snake.length / 10) * speedStep;
+  return Math.max(baseMoveTime - reduction, minMoveTime);
 }
 
 function updateSpeed() {


### PR DESCRIPTION
## Summary
- Increase snake movement speed at length 10 and 20
- Spawn occasional speed-up items that temporarily boost speed tenfold
- Document new speed mechanics in README

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_6898488efa3083289738bdca781970fd