### PR TITLE
Increase arrow button size

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,12 +20,12 @@
   <button id="restart" class="hidden mx-auto mt-2 py-2 px-5 text-xl border-2 border-gray-700">Restart</button>
   <div id="controls" class="mt-5 inline-block">
     <div class="row flex justify-center">
-      <button id="up" aria-label="up" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">↑</button>
+      <button id="up" aria-label="up" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-28 sm:h-28 sm:text-6xl">↑</button>
     </div>
     <div class="row flex justify-center">
-      <button id="left" aria-label="left" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">←</button>
-      <button id="down" aria-label="down" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">↓</button>
-      <button id="right" aria-label="right" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-20 sm:h-20 sm:text-4xl">→</button>
+      <button id="left" aria-label="left" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-28 sm:h-28 sm:text-6xl">←</button>
+      <button id="down" aria-label="down" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-28 sm:h-28 sm:text-6xl">↓</button>
+      <button id="right" aria-label="right" class="w-[48rem] h-[48rem] text-[48rem] m-[5px] rounded-full border-2 border-gray-700 flex items-center justify-center leading-none sm:w-28 sm:h-28 sm:text-6xl">→</button>
     </div>
   </div>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- enlarge arrow button controls to `sm:w-28 sm:h-28 sm:text-6xl` for easier gameplay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68987453e9588328a5935c5ab7c161a0